### PR TITLE
Version bump 1.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/avisi-cloud/structurizr-site-generatr:1.3.0
+FROM ghcr.io/avisi-cloud/structurizr-site-generatr:1.5.0
 
 USER root
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Using this image, one can render the site using CI config like following:
 
 ```yaml
 site:
-  image: ghcr.io/mgetka/structurizr-site-generatr-ci:1.3.0
+  image: ghcr.io/mgetka/structurizr-site-generatr-ci:1.5.0
   stage: build
   script:
     - structurizr-site-generatr generate-site -w workspace.dsl --assets-dir assets


### PR DESCRIPTION
This bumps the version to most recent 1.5.0 release of [structurizr-site-generatr](https://github.com/avisi-cloud/structurizr-site-generatr/releases/tag/1.5.0) which includes a version bump [structerizr](https://github.com/structurizr/java/releases/tag/v3.0.0) 3.0.0