### PR TITLE
Bump version to 1.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/avisi-cloud/structurizr-site-generatr:1.5.0
+FROM ghcr.io/avisi-cloud/structurizr-site-generatr:1.5.1
 
 USER root
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Using this image, one can render the site using CI config like following:
 
 ```yaml
 site:
-  image: ghcr.io/mgetka/structurizr-site-generatr-ci:1.5.0
+  image: ghcr.io/mgetka/structurizr-site-generatr-ci:1.5.1
   stage: build
   script:
     - structurizr-site-generatr generate-site -w workspace.dsl --assets-dir assets


### PR DESCRIPTION
This PR bumps the version of structurizr-site-generatr to the latest version [1.5.1](https://github.com/avisi-cloud/structurizr-site-generatr/releases/tag/1.5.1), which includes a structurizr update to [v3.2.1](https://github.com/structurizr/java/releases/tag/v3.2.1).